### PR TITLE
Consume _trcGlobal via context

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -12,7 +12,6 @@
 <body>
     <script>
         var _sheetRefGlobal = null;
-        var _trcGlobal = null;
     </script>
 
     <div id="example"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,9 +2551,9 @@
       "integrity": "sha512-Actw18afe4ySrvsn0HhbQtSTTzMyBN8/lwiWRrP9Ft+Ftc3TUo2smjLvIY4tOlbW4okIpVyn5xaJB20kahqAhg=="
     },
     "trc-react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/trc-react/-/trc-react-2.0.0.tgz",
-      "integrity": "sha512-fM+wOZnoXFzXphcbKk9TcslVFSi8LOY/Dse2bj0Iiz5FhdXFAEeiT1mUAV1M6u17PDVptCELTm7GgijMSdh9SQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trc-react/-/trc-react-2.1.0.tgz",
+      "integrity": "sha512-ETby3z23KDaBtfgv2tgGa8EZMn7hn+swLUT8MSo8en7BODQ8ZJmub8l/RzIynlHJ7rbca0rpieoi8qukjNEVQw==",
       "requires": {
         "@emotion/core": "^10.0.28",
         "@emotion/styled": "^10.0.27",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "trc-analyze": "^1.6.0",
-    "trc-react": "^2.0.0",
+    "trc-react": "^2.1.0",
     "trc-sheet": "^1.12.0"
   },
   "devDependencies": {

--- a/src/components/FieldInputs.tsx
+++ b/src/components/FieldInputs.tsx
@@ -87,17 +87,15 @@ export class FieldInputs extends React.Component<IProps, IState> {
         const { data, Keys, Names } = this.props;
 
         const inputs = Names.map((name: string, i) => (
-            <div>
-                <TextInput
-                    key={name}
-                    type="text"
-                    placeholder={"(" + name + ")"}
-                    value={this.state.Vals[name]}
-                    onChange={(x) => this.updateFieldState(name, x.target.value, Keys[i])}
-                    label={name}
-                    list={`datalist-${Keys[i]}`}
-                />
-            </div>
+            <TextInput
+                key={name}
+                type="text"
+                placeholder={"(" + name + ")"}
+                value={this.state.Vals[name]}
+                onChange={(x) => this.updateFieldState(name, x.target.value, Keys[i])}
+                label={name}
+                list={`datalist-${Keys[i]}`}
+            />
         ));
 
         return (
@@ -108,8 +106,8 @@ export class FieldInputs extends React.Component<IProps, IState> {
 
                 {this.state.dataListItems.length > 0 && (
                     <datalist id={`datalist-${this.state.activeInputKey}`}>
-                        {this.state.dataListItems.map((value: string, i: number) => (
-                            <option key={i} value={value} />
+                        {this.state.dataListItems.map((value: string) => (
+                            <option key={value} value={value} />
                         ))}
                     </datalist>
                 )}


### PR DESCRIPTION
This PR allows us to consume `_trcGlobal` via React's context api, instead of using a global variable.

Should be merged only after `trc-search 2.1.0` is published.